### PR TITLE
android-ndk hook fixes + test_package

### DIFF
--- a/recipes/android-ndk/all/conandata.yml
+++ b/recipes/android-ndk/all/conandata.yml
@@ -1,12 +1,12 @@
 sources:
   "r21d":
     url:
-      "Windows":
-          url: https://dl.google.com/android/repository/android-ndk-r21d-windows-x86_64.zip
-          sha256: 18335e57f8acab5a4acf6a2204130e64f99153015d55eb2667f8c28d4724d927
-      "Linux":
-          url: https://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip
-          sha256: dd6dc090b6e2580206c64bcee499bc16509a5d017c6952dcd2bed9072af67cbd
-      "Macos":
-          url: https://dl.google.com/android/repository/android-ndk-r21d-darwin-x86_64.zip
-          sha256: 5851115c6fc4cce26bc320295b52da240665d7ff89bda2f5d5af1887582f5c48
+      Windows:
+        url: "https://dl.google.com/android/repository/android-ndk-r21d-windows-x86_64.zip"
+        sha256: "18335e57f8acab5a4acf6a2204130e64f99153015d55eb2667f8c28d4724d927"
+      Linux:
+        url: "https://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip"
+        sha256: "dd6dc090b6e2580206c64bcee499bc16509a5d017c6952dcd2bed9072af67cbd"
+      Macos:
+        url: "https://dl.google.com/android/repository/android-ndk-r21d-darwin-x86_64.zip"
+        sha256: "5851115c6fc4cce26bc320295b52da240665d7ff89bda2f5d5af1887582f5c48"

--- a/recipes/android-ndk/all/conanfile.py
+++ b/recipes/android-ndk/all/conanfile.py
@@ -3,7 +3,7 @@ from conans.errors import ConanInvalidConfiguration
 import os
 
 
-class AndroidNDKInstallerConan(ConanFile):
+class AndroidNDKConan(ConanFile):
     name = "android-ndk"
     description = "The Android NDK is a toolset that lets you implement parts of your app in " \
                   "native code, using languages such as C and C++"
@@ -15,76 +15,104 @@ class AndroidNDKInstallerConan(ConanFile):
     no_copy_source = True
     exports_sources = ["cmake-wrapper.cmd", "cmake-wrapper"]
 
-    settings = {"os": ["Windows", "Linux", "Macos"],
-                "arch": ["x86_64"]}
+    settings = "os", "arch"
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
 
-    def configure(self):
-        if self.settings.arch != 'x86_64':
-            raise ConanInvalidConfiguration("No binaries available for other than 'x86_64' architectures")
+    # some methods assume they are run in cross build mode, using android-ndk as a build requirement
 
-    def source(self):
+    def configure(self):
+        available_arch = ("x86_64", )
+        available_os = ("Linux", "Macos", "Windows", )
+        if self.settings.arch not in available_arch:
+            raise ConanInvalidConfiguration("No binaries available for arch={} (only {} is available)".format(self.settings.arch, available_arch))
+        if self.settings.os not in available_os:
+            raise ConanInvalidConfiguration("No binaries available for os={} (only {} are available".format(self.settings.os, available_os))
+
+        available_target_arch = ("armv7", "armv8", "x86", "x86_64",)
+        if hasattr(self, "settings_target") and self.settings_target:
+            if self.settings_target.arch not in available_target_arch:
+                raise ConanInvalidConfiguration("android-ndk only supports the following target architectures: {}".format(available_target_arch))
+            if self.settings_target.compiler != "clang":
+                raise ConanInvalidConfiguration("android-ndk only supports the clang compiler")
+            if self.settings_target.os != "Android":
+                raise ConanInvalidConfiguration("android-ndk only supports target os=Android")
+
+    def build(self):
+        # Since we're downloading settings dependent binaries, download in `build` instead of `source`
         tarballs = self.conan_data["sources"][self.version]["url"]
         tools.get(**tarballs[str(self.settings.os)])
         extracted_dir = self.name + "-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
 
-    def build(self):
-        pass # no build, but please also no warnings
-
-    # from here on, everything is assumed to run in 2 profile mode, when using the ndk as a build requirement
+    @property
+    def _host_os_android(self):
+        return {
+            "Linux": "linux",
+            "Macos": "darwin",
+            "Windows": "windows",
+        }[str(self.settings.os)]
 
     @property
-    def _platform(self):
-        return {"Windows": "windows",
-                "Macos": "darwin",
-                "Linux": "linux"}.get(str(self.settings_build.os))
+    def _host_arch_android(self):
+        return {
+            "x86_64": "x86_64",
+        }[str(self.settings.arch)]
+
+    @property
+    def _host_os_arch_android(self):
+        return "{}-{}".format(self._host_os_android, self._host_arch_android)
 
     @property
     def _android_abi(self):
-        return {"x86": "x86",
-                "x86_64": "x86_64",
-                "armv7": "armeabi-v7a",
-                "armv8": "arm64-v8a"}.get(str(self.settings_target.arch))
+        return {
+            "armv7": "armeabi-v7a",
+            "armv8": "arm64-v8a",
+            "x86": "x86",
+            "x86_64": "x86_64",
+        }[str(self.settings_target.arch)]
 
     @property
     def _llvm_triplet(self):
-        arch = {'armv7': 'arm',
-                'armv8': 'aarch64',
-                'x86': 'i686',
-                'x86_64': 'x86_64'}.get(str(self.settings_target.arch))
-        abi = 'androideabi' if self.settings_target.arch == 'armv7' else 'android'
-        return '%s-linux-%s' % (arch, abi)
+        arch = {
+            "armv7": "arm",
+            "armv8": "aarch64",
+            "x86": "i686",
+            "x86_64": "x86_64",
+        }[str(self.settings_target.arch)]
+        abi = "androideabi" if self.settings_target.arch == "armv7" else "android"
+        return "%s-linux-%s" % (arch, abi)
 
     @property
     def _clang_triplet(self):
-        arch = {'armv7': 'armv7a',
-                'armv8': 'aarch64',
-                'x86': 'i686',
-                'x86_64': 'x86_64'}.get(str(self.settings_target.arch))
-        abi = 'androideabi' if self.settings_target.arch == 'armv7' else 'android'
-        return '%s-linux-%s' % (arch, abi)
+        arch = {
+            "armv7": "armv7a",
+            "armv8": "aarch64",
+            "x86": "i686",
+            "x86_64": "x86_64",
+        }.get(str(self.settings_target.arch))
+        abi = "androideabi" if self.settings_target.arch == "armv7" else "android"
+        return "%s-linux-%s" % (arch, abi)
 
     def _fix_permissions(self):
-        if os.name != 'posix':
+        if os.name != "posix":
             return
-        for root, _, files in os.walk(self.package_folder):
+        for root, _, files in os.walk(self._packaged_tar_root):
             for filename in files:
                 filename = os.path.join(root, filename)
-                with open(filename, 'rb') as f:
+                with open(filename, "rb") as f:
                     sig = f.read(4)
                     if type(sig) is str:
                         sig = [ord(s) for s in sig]
                     else:
                         sig = [s for s in sig]
                     if len(sig) > 2 and sig[0] == 0x23 and sig[1] == 0x21:
-                        self.output.info('chmod on script file: "%s"' % filename)
+                        self.output.info("chmod on script file: '%s'" % filename)
                         self._chmod_plus_x(filename)
                     elif sig == [0x7F, 0x45, 0x4C, 0x46]:
-                        self.output.info('chmod on ELF file: "%s"' % filename)
+                        self.output.info("chmod on ELF file: '%s'" % filename)
                         self._chmod_plus_x(filename)
                     elif sig == [0xCA, 0xFE, 0xBA, 0xBE] or \
                          sig == [0xBE, 0xBA, 0xFE, 0xCA] or \
@@ -92,121 +120,117 @@ class AndroidNDKInstallerConan(ConanFile):
                          sig == [0xCF, 0xFA, 0xED, 0xFE] or \
                          sig == [0xFE, 0xEF, 0xFA, 0xCE] or \
                          sig == [0xCE, 0xFA, 0xED, 0xFE]:
-                        self.output.info('chmod on Mach-O file: "%s"' % filename)
+                        self.output.info("chmod on Mach-O file: '%s'" % filename)
                         self._chmod_plus_x(filename)
 
+    @property
+    def _packaged_tar_root(self):
+        return os.path.join(self.package_folder, "bin")
+
     def package(self):
-        self.copy(pattern="*", dst=".", src=self._source_subfolder, keep_path=True, symlinks=True)
-        self.copy(pattern="*", dst="bin", src=self._source_subfolder, keep_path=True, symlinks=True)
         self.copy(pattern="*NOTICE", dst="licenses", src=self._source_subfolder)
         self.copy(pattern="*NOTICE.toolchain", dst="licenses", src=self._source_subfolder)
-        self.copy("cmake-wrapper.cmd")
-        self.copy("cmake-wrapper")
+        self.copy(pattern="*", dst=self._packaged_tar_root, src=self._source_subfolder, keep_path=True, symlinks=True)
+        self.copy("cmake-wrapper.cmd", dst=self._packaged_tar_root)
+        self.copy("cmake-wrapper", dst=self._packaged_tar_root)
         self._fix_permissions()
 
-    @property
-    def _host(self):
-        return self._platform + "-x86_64"
+        tools.remove_files_by_mask(os.path.join(self.package_folder, "bin", "prebuilt", self._host_os_arch_android, "lib", "pkgconfig"), "*.pc")
 
     @property
     def _ndk_root(self):
-        return os.path.join(self.package_folder, "toolchains", "llvm", "prebuilt", self._host)
+        return os.path.join(self._packaged_tar_root, "toolchains", "llvm", "prebuilt", self._host_os_arch_android)
 
     def _tool_name(self, tool):
-        if 'clang' in tool:
-            suffix = '.cmd' if self.settings_build.os == 'Windows' else ''
-            return '%s%s-%s%s' % (self._clang_triplet, self.settings_target.os.api_level, tool, suffix)
+        if "clang" in tool:
+            suffix = ".cmd" if self.settings_build.os == "Windows" else ""
+            return "%s%s-%s%s" % (self._clang_triplet, self.settings_target.os.api_level, tool, suffix)
         else:
-            suffix = '.exe' if self.settings_build.os == 'Windows' else ''
-            return '%s-%s%s' % (self._llvm_triplet, tool, suffix)
+            suffix = ".exe" if self.settings_build.os == "Windows" else ""
+            return "%s-%s%s" % (self._llvm_triplet, tool, suffix)
 
     def _define_tool_var(self, name, value):
-        ndk_bin = os.path.join(self._ndk_root, 'bin')
+        ndk_bin = os.path.join(self._ndk_root, "bin")
         path = os.path.join(ndk_bin, self._tool_name(value))
-        self.output.info('Creating %s environment variable: %s' % (name, path))
+        self.output.info("Creating %s environment variable: %s" % (name, path))
         return path
-
-    # def package_id(self):
-    #     self.info.include_build_settings()
-    #     del self.info.settings.arch
-    #     del self.info.settings.os.api_level
 
     @staticmethod
     def _chmod_plus_x(filename):
-        if os.name == 'posix':
+        if os.name == "posix":
             os.chmod(filename, os.stat(filename).st_mode | 0o111)
 
     def package_info(self):
-        # test shall pass, so this runs also in the build as build requirement context
-        # ndk-build: https://developer.android.com/ndk/guides/ndk-build
-        self.env_info.PATH.append(os.path.join(self.package_folder, 'bin'))
+        # android-ndk must be able to build and tested in non cross build mode.
+        # So set those variables that do not depend on the target (target arch, target api level).
+        # This enables ndk-build: https://developer.android.com/ndk/guides/ndk-build
+        bin_path = os.path.join(self._packaged_tar_root, "bin")
+        self.output.info("Appending PATH environment variable: {}".format(bin_path))
+        self.env_info.PATH.append(bin_path)
 
-        # this is not enough, I can kill that .....
-        if not hasattr(self, 'settings_target'):
-            return
+        self.output.info("Creating ANDROID_NDK_HOME environment variable: %s" % self.package_folder)
+        self.env_info.ANDROID_NDK_HOME = self._packaged_tar_root
 
-        # interestingly I can reach that with
-        # conan test --profile:build nsdk-default --profile:host default /Users/a4z/elux/conan/myrecipes/android-ndk/all/test_package android-ndk/r21d@
-        if  self.settings_target is None:
-            return
+        # FIXME: should `android-api` be added to exceptions of KB-H020?
+        self.cpp_info.builddirs.extend([
+            os.path.join("bin", "build", "cmake"),
+            os.path.join("bin", "sources", "cxx-stl", "llvm-libc++abi"),
+            os.path.join("bin", "bin", "sources", "third_party", "googletest", "cmake", "internal_utils.cmake"),
+            os.path.join("bin", "sources", "third_party", "googletest", "cmake", "internal_utils.cmake"),
+        ])
 
-        # And if we are not building for Android, why bother at all
-        if not self.settings_target.os == "Android":
-            return
+        # The settings hereafter depend on the target system.
+        if hasattr(self, "settings_target") and self.settings_target is not None:
+            self.output.info("Creating NDK_ROOT environment variable: %s" % self._ndk_root)
+            self.env_info.NDK_ROOT = self._ndk_root
 
-        self.output.info('Creating NDK_ROOT environment variable: %s' % self._ndk_root)
-        self.env_info.NDK_ROOT = self._ndk_root
+            ndk_sysroot = os.path.join(self._ndk_root, "sysroot")
+            self.output.info("Creating CONAN_CMAKE_FIND_ROOT_PATH environment variable: %s" % ndk_sysroot)
+            self.env_info.CONAN_CMAKE_FIND_ROOT_PATH = ndk_sysroot
 
-        self.output.info('Creating ANDROID_NDK_HOME environment variable: %s' % self.package_folder)
-        self.env_info.ANDROID_NDK_HOME = self.package_folder
+            self.output.info("Creating SYSROOT environment variable: %s" % ndk_sysroot)
+            self.env_info.SYSROOT = ndk_sysroot
 
-        self.output.info('Creating CHOST environment variable: %s' % self._llvm_triplet)
-        self.env_info.CHOST = self._llvm_triplet
+            self.output.info("Creating self.cpp_info.sysroot: %s" % ndk_sysroot)
+            self.cpp_info.sysroot = ndk_sysroot
 
-        ndk_sysroot = os.path.join(self._ndk_root, 'sysroot')
-        self.output.info('Creating CONAN_CMAKE_FIND_ROOT_PATH environment variable: %s' % ndk_sysroot)
-        self.env_info.CONAN_CMAKE_FIND_ROOT_PATH = ndk_sysroot
+            self.output.info("Creating CHOST environment variable: %s" % self._llvm_triplet)
+            self.env_info.CHOST = self._llvm_triplet
 
-        self.output.info('Creating SYSROOT environment variable: %s' % ndk_sysroot)
-        self.env_info.SYSROOT = ndk_sysroot
+            self.output.info("Creating ANDROID_NATIVE_API_LEVEL environment variable: %s" % self.settings_target.os.api_level)
+            self.env_info.ANDROID_NATIVE_API_LEVEL = str(self.settings_target.os.api_level)
 
-        self.output.info('Creating self.cpp_info.sysroot: %s' % ndk_sysroot)
-        self.cpp_info.sysroot = ndk_sysroot
+            self._chmod_plus_x(os.path.join(self.package_folder, "bin", "cmake-wrapper"))
+            cmake_wrapper = "cmake-wrapper.cmd" if self.settings.os == "Windows" else "cmake-wrapper"
+            cmake_wrapper = os.path.join(self._packaged_tar_root, cmake_wrapper)
+            self.output.info("Creating CONAN_CMAKE_PROGRAM environment variable: %s" % cmake_wrapper)
+            self.env_info.CONAN_CMAKE_PROGRAM = cmake_wrapper
 
-        self.output.info('Creating ANDROID_NATIVE_API_LEVEL environment variable: %s' % self.settings_target.os.api_level)
-        self.env_info.ANDROID_NATIVE_API_LEVEL = str(self.settings_target.os.api_level)
+            toolchain = os.path.join(self._packaged_tar_root, "build", "cmake", "android.toolchain.cmake")
+            self.output.info("Creating CONAN_CMAKE_TOOLCHAIN_FILE environment variable: %s" % toolchain)
+            self.env_info.CONAN_CMAKE_TOOLCHAIN_FILE = toolchain
 
-        self._chmod_plus_x(os.path.join(self.package_folder, "cmake-wrapper"))
-        cmake_wrapper = "cmake-wrapper.cmd" if self.settings.os == "Windows" else "cmake-wrapper"
-        cmake_wrapper = os.path.join(self.package_folder, cmake_wrapper)
-        self.output.info('Creating CONAN_CMAKE_PROGRAM environment variable: %s' % cmake_wrapper)
-        self.env_info.CONAN_CMAKE_PROGRAM = cmake_wrapper
+            self.env_info.CC = self._define_tool_var("CC", "clang")
+            self.env_info.CXX = self._define_tool_var("CXX", "clang++")
+            self.env_info.LD = self._define_tool_var("LD", "ld")
+            self.env_info.AR = self._define_tool_var("AR", "ar")
+            self.env_info.AS = self._define_tool_var("AS", "as")
+            self.env_info.RANLIB = self._define_tool_var("RANLIB", "ranlib")
+            self.env_info.STRIP = self._define_tool_var("STRIP", "strip")
+            self.env_info.ADDR2LINE = self._define_tool_var("ADDR2LINE", "addr2line")
+            self.env_info.NM = self._define_tool_var("NM", "nm")
+            self.env_info.OBJCOPY = self._define_tool_var("OBJCOPY", "objcopy")
+            self.env_info.OBJDUMP = self._define_tool_var("OBJDUMP", "objdump")
+            self.env_info.READELF = self._define_tool_var("READELF", "readelf")
+            self.env_info.ELFEDIT = self._define_tool_var("ELFEDIT", "elfedit")
 
-        toolchain = os.path.join(self.package_folder, "build", "cmake", "android.toolchain.cmake")
-        self.output.info('Creating CONAN_CMAKE_TOOLCHAIN_FILE environment variable: %s' % toolchain)
-        self.env_info.CONAN_CMAKE_TOOLCHAIN_FILE = toolchain
+            self.env_info.ANDROID_PLATFORM = "android-%s" % self.settings_target.os.api_level
+            self.env_info.ANDROID_TOOLCHAIN = "clang"
+            self.env_info.ANDROID_ABI = self._android_abi
+            libcxx_str = str(self.settings_target.compiler.libcxx)
+            self.env_info.ANDROID_STL = libcxx_str if libcxx_str.startswith("c++_") else "c++_shared"
 
-        self.env_info.CC = self._define_tool_var('CC', 'clang')
-        self.env_info.CXX = self._define_tool_var('CXX', 'clang++')
-        self.env_info.LD = self._define_tool_var('LD', 'ld')
-        self.env_info.AR = self._define_tool_var('AR', 'ar')
-        self.env_info.AS = self._define_tool_var('AS', 'as')
-        self.env_info.RANLIB = self._define_tool_var('RANLIB', 'ranlib')
-        self.env_info.STRIP = self._define_tool_var('STRIP', 'strip')
-        self.env_info.ADDR2LINE = self._define_tool_var('ADDR2LINE', 'addr2line')
-        self.env_info.NM = self._define_tool_var('NM', 'nm')
-        self.env_info.OBJCOPY = self._define_tool_var('OBJCOPY', 'objcopy')
-        self.env_info.OBJDUMP = self._define_tool_var('OBJDUMP', 'objdump')
-        self.env_info.READELF = self._define_tool_var('READELF', 'readelf')
-        self.env_info.ELFEDIT = self._define_tool_var('ELFEDIT', 'elfedit')
-
-        self.env_info.ANDROID_PLATFORM = "android-%s" % self.settings_target.os.api_level
-        self.env_info.ANDROID_TOOLCHAIN = "clang"
-        self.env_info.ANDROID_ABI = self._android_abi
-        libcxx_str = str(self.settings_target.compiler.libcxx)
-        self.env_info.ANDROID_STL = libcxx_str if libcxx_str.startswith('c++_') else 'c++_shared'
-
-        self.env_info.CMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "BOTH"
-        self.env_info.CMAKE_FIND_ROOT_PATH_MODE_LIBRARY = "BOTH"
-        self.env_info.CMAKE_FIND_ROOT_PATH_MODE_INCLUDE = "BOTH"
-        self.env_info.CMAKE_FIND_ROOT_PATH_MODE_PACKAGE = "BOTH"
+            self.env_info.CMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "NEVER"
+            self.env_info.CMAKE_FIND_ROOT_PATH_MODE_LIBRARY = "BOTH"
+            self.env_info.CMAKE_FIND_ROOT_PATH_MODE_INCLUDE = "BOTH"
+            self.env_info.CMAKE_FIND_ROOT_PATH_MODE_PACKAGE = "BOTH"

--- a/recipes/android-ndk/all/test_package/conanfile.py
+++ b/recipes/android-ndk/all/test_package/conanfile.py
@@ -1,12 +1,27 @@
 from conans import ConanFile, tools
 import os
+import shutil
 
 
 class TestPackgeConan(ConanFile):
     settings = "os", "arch"
 
+
     def build(self):
-        pass #nothing to do, not warnings please
+        if not tools.cross_building(self.settings):
+            tools.mkdir(os.path.join(self.build_folder, "jni"))
+            for fn in ("jni/Android.mk", "jni/test_package.c"):
+                shutil.copy(os.path.join(self.source_folder, fn),
+                            os.path.join(self.build_folder, fn))
+            args = [
+                "NDK_PROJECT_PATH='{}'".format(self.build_folder),
+                "APP_ABI={}".format("arm64-v8a"),  # FIXME
+                "APP_PLATFORM={}".format(20),  # FIXME
+                "V=1",
+            ]
+            with tools.environment_append({"VERBOSE": "yes"}):
+                self.run("ndk-build {}".format(" ".join(args)), run_environment=True)
+
 
     def test(self):
         if not tools.cross_building(self):

--- a/recipes/android-ndk/all/test_package/jni/Android.mk
+++ b/recipes/android-ndk/all/test_package/jni/Android.mk
@@ -1,0 +1,9 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := test_package
+LOCAL_SRC_FILES := test_package.c
+LOCAL_LDLIBS := -llog
+
+include $(BUILD_SHARED_LIBRARY)

--- a/recipes/android-ndk/all/test_package/jni/test_package.c
+++ b/recipes/android-ndk/all/test_package/jni/test_package.c
@@ -1,0 +1,6 @@
+#include <android/log.h>
+
+__attribute__((visibility("default")))
+void test_package_log_message(const char *msg) {
+    __android_log_print(ANDROID_LOG_DEBUG, "test_pacakge", "%s", msg);
+}

--- a/recipes/android-ndk/all/test_package/jni/test_package.c
+++ b/recipes/android-ndk/all/test_package/jni/test_package.c
@@ -2,5 +2,5 @@
 
 __attribute__((visibility("default")))
 void test_package_log_message(const char *msg) {
-    __android_log_print(ANDROID_LOG_DEBUG, "test_pacakge", "%s", msg);
+    __android_log_print(ANDROID_LOG_DEBUG, "test_package", "%s", msg);
 }

--- a/recipes/android-ndk/config.yml
+++ b/recipes/android-ndk/config.yml
@@ -1,4 +1,3 @@
----
-    versions:
-      "r21d":
-        folder: all
+versions:
+  "r21d":
+    folder: all


### PR DESCRIPTION
Let's get this working.
https://github.com/conan-io/conan-center-index/issues/3996 was opened today because bincrafters' android-ndk-installer recipe is outdated.
It looks like https://github.com/conan-io/conan-center-index/pull/3004 is stalled.

- this pr fixes the hook warnings/errors (on my system).
There is still a FIXME, but let's discuss that on https://github.com/conan-io/conan-center-index/pull/3004
- add a little `ndk-build` test_package. Too bad there is no way to add a cmake test_package (that I know of).
This is really missing from conan.

I tested this as `conan create . android-ndk/r21d@` + building `zlib/1.2.11` in cross building mode, only on Linux.
Not tested on Macos or Windows.